### PR TITLE
Test palette

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,9 +35,9 @@ app.get('/api/v1/project', (request, response) => {
 //get endpoint for ALL resources on palettes table
 
 app.get('/api/v1/palettes', (request, response) => {
-  database('palettes').select()
   .then(palette => {
     return response.status(200).json(palette);
+  database('palettes').select()
   })
   .catch(error => {
     return response.status(500).json({ error })
@@ -51,7 +51,8 @@ app.get('/api/v1/project/:id', (request, response) => {
   .select()
   .then(project => {
     if(project.length) {
-      return response.status(200).json(project);
+      return response.status(200).json(
+project);
     } else {
       return response.status(404).json({ error: `Couldn't find project with id: ${request.params.id}` });
     }
@@ -60,7 +61,6 @@ app.get('/api/v1/project/:id', (request, response) => {
     return response.status(500).json({ error });
   })
 });
-
 //get for single palette /palettes/:id
 
 app.get('/api/v1/palettes/:id', (request, response) => {

--- a/server.js
+++ b/server.js
@@ -35,9 +35,9 @@ app.get('/api/v1/project', (request, response) => {
 //get endpoint for ALL resources on palettes table
 
 app.get('/api/v1/palettes', (request, response) => {
-  .then(palette => {
-    return response.status(200).json(palette);
   database('palettes').select()
+   .then(palette => {
+    return response.status(200).json(palette);
   })
   .catch(error => {
     return response.status(500).json({ error })
@@ -196,5 +196,7 @@ app.delete('/api/v1/project/:id', (request, response) => {
       response.status(500).json({ error })
     });
  });
+
+module.exports = app
 
 

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ app.use(bodyParser.json());
 // app.use(express.json());
 // require('dotenv').config();
 
-app.set('port', process.env.PORT || 3001);
+app.set('port', process.env.PORT || 3000);
 
 app.listen(app.get('port'), () => console.log(`App is running 😃 on port ${app.get('port')}`));
 

--- a/server.test.js
+++ b/server.test.js
@@ -82,4 +82,18 @@ describe('GET /api/v1/palettes', () {
 	})
 })
 
+describe('GET /api/v1/palettes:id', () {
+	it('should return a palette with an id that matches the params id', () => {
+		//set up 
+		// it should grab the first palette from the database
+		//the id should = the palette id
+
+		//execution
+		//should declare the palettes 
+		//declare result should take the first palette from the response body
+
+		//expectation
+		//expected the result to be the palette with th matching id of the palette 
+	})
+})
 	

--- a/server.test.js
+++ b/server.test.js
@@ -115,12 +115,12 @@ describe('Server', () => {
 			//setup
 			const newPalette = {"color_1": "FFFFFF", "color_2": "FFFFFF", "color_3": "888888", "color_4": "000000", "color_5": "00FFFF"}
 
-			const response = await request(app).post('/api/v1/palettes').send(newPalette)
-			const id = response.body.id;
+			const res = await request(app).post('/api/v1/palettes').send(newPalette)
+			const id = res.body.id;
 			const palette = await database('palettes').where({ id }).first();
 			
 			expect(palette.color_1).toEqual(newPalette.color_1);
-			expect(response.status).toEqual(201);
+			expect(res.status).toEqual(201);
 		});
 
 			it('should return an error if a not all required parameters are met', async () => {
@@ -147,7 +147,14 @@ describe('Server', () => {
 			expect(res.status).toEqual(200);
 		});
 
-			it('should return a 404 status if request has no matching id', () => {
+			it('should return a 404 status if request has no matching id', async () => {
+				let paletteToUpdate = await database('palettes').first();
+	
+				const res = await request(app).put('/api/v1/palettes/10').send(paletteToUpdate)
+				const expectedMsg = "{\"error\":\"Couldn't update: Palette does not exist\"}"
+
+				expect(res.status).toEqual(404);
+				expect(res.text).toBe(expectedMsg)
 			//setup
 			//it should declare the id of the request
 			//should declare the body of the request as updated palette

--- a/server.test.js
+++ b/server.test.js
@@ -94,6 +94,36 @@ describe('GET /api/v1/palettes:id', () {
 
 		//expectation
 		//expected the result to be the palette with th matching id of the palette 
-	})
-})
+	});
+});
+
+describe('POST /api/v1/palettes', () {
+	it('should post a palette to the palettes database', () {
+		//setup
+		//it should declare the palette
+
+		//execution 
+		//result should be declared with the palette posted
+		//palettes should be declared as all the palettes in the database
+
+		//expected 
+		//a 200 reponse
+		//the palette color to be the same as the new palette
+	});
+
+		it('should return an error if a not all required parameters are met', () {
+		//setup
+		//it should declare the palette
+
+		//execution 
+		//result should be declared with the palette posted
+		//palettes should be declared as all the palettes in the database
+
+		//expected 
+		//an error status 
+		//a error message
+		//error: 
+    //      `Expected format: { name: <String> } You're missing "${ requiredParameter }" property.
+	});
+});
 	

--- a/server.test.js
+++ b/server.test.js
@@ -126,4 +126,30 @@ describe('POST /api/v1/palettes', () {
     //      `Expected format: { name: <String> } You're missing "${ requiredParameter }" property.
 	});
 });
+
+describe('PUT /api/v1/palettes/:id', () => {
+	it('should return a 200 status if request has a matching id', () {
+		//setup
+		//it should declare the id of the request
+		//should declare the body of the request as updated palette
+
+		//execution 
+		//should search in the database for a palette with the matching id of the request and update that palette
+
+		//expected 
+		//a 200 status
+	});
+
+		it('should return a 404 status if request has no matching id', () {
+		//setup
+		//it should declare the id of the request
+		//should declare the body of the request as updated palette
+
+		//execution 
+		//should search the database for a matching id
+
+		//expected 
+		//a 404 status will be returned with an error message
+	});
+});
 	

--- a/server.test.js
+++ b/server.test.js
@@ -132,15 +132,24 @@ describe('Server', () => {
 	});
 
 	describe('PUT /api/v1/palettes/:id', () => {
-		it('should return a 200 status if request has a matching id', () => {
+		it('should return a 200 status if request has a matching id', async () => {
 			//setup
+			let paletteToUpdate = await database('palettes').first()
+			const id = paletteToUpdate.id
+			const color_1 = 'FFFFFF'
+			paletteToUpdate = {...paletteToUpdate, color_1}
 			//it should declare the id of the request
 			//should declare the body of the request as updated palette
 
 			//execution 
+			const res = await request(app).put(`/api/v1/palettes/${id}`).send(paletteToUpdate)
+			console.log(res)
+			const palette = await database('palettes').where({id}).first()
 			//should search in the database for a palette with the matching id of the request and update that palette
 
 			//expected 
+			expect(color_1).toEqual(palette.color_1)
+			expect(res.status).toEqual(200)
 			//a 200 status
 		});
 

--- a/server.test.js
+++ b/server.test.js
@@ -102,12 +102,12 @@ describe('Server', () => {
 		});
 
 		it('should return an error if the id is not found', async () => {
-			const res = await request(app).get('/api/v1/palettes/10')
-      const expectedMsg = "{\"error\":\"Couldn't find palette with id: 10\"}"
+			const res = await request(app).get('/api/v1/palettes/10');
+      const expectedMsg = "{\"error\":\"Couldn't find palette with id: 10\"}";
 
-      expect(res.status).toBe(404)
-      expect(res.text).toBe(expectedMsg)
-		})
+      expect(res.status).toBe(404);
+      expect(res.text).toBe(expectedMsg);
+		});
 	});
 
 	describe('POST /api/v1/palettes', () => {
@@ -123,19 +123,13 @@ describe('Server', () => {
 			expect(response.status).toEqual(201);
 		});
 
-			it('should return an error if a not all required parameters are met', () => {
-			//setup
-			//it should declare the palette
+			it('should return an error if a not all required parameters are met', async () => {
+			const palette = await database('palettes').first();
+			const newPalette = {color_1: ''};
 
-			//execution 
-			//result should be declared with the palette posted
-			//palettes should be declared as all the palettes in the database
+			const res = await request(app).post('/api/v1/palettes').send();
 
-			//expected 
-			//an error status 
-			//a error message
-			//error: 
-	    //      `Expected format: { name: <String> } You're missing "${ requiredParameter }" property.
+			expect(res.status).toBe(422);
 		});
 	});
 

--- a/server.test.js
+++ b/server.test.js
@@ -100,6 +100,14 @@ describe('Server', () => {
 
 			expect(palette).toEqual(expectedPalette);
 		});
+
+		it('should return an error if the id is not found', async () => {
+			const res = await request(app).get('/api/v1/palettes/10')
+      const expectedMsg = "{\"error\":\"Couldn't find palette with id: 10\"}"
+
+      expect(res.status).toBe(404)
+      expect(res.text).toBe(expectedMsg)
+		})
 	});
 
 	describe('POST /api/v1/palettes', () => {
@@ -133,24 +141,16 @@ describe('Server', () => {
 
 	describe('PUT /api/v1/palettes/:id', () => {
 		it('should return a 200 status if request has a matching id', async () => {
-			//setup
-			let paletteToUpdate = await database('palettes').first()
-			const id = paletteToUpdate.id
-			const color_1 = 'FFFFFF'
-			paletteToUpdate = {...paletteToUpdate, color_1}
-			//it should declare the id of the request
-			//should declare the body of the request as updated palette
+			let paletteToUpdate = await database('palettes').first();
+			const id = paletteToUpdate.id;
+			const color_1 = 'FFFFFF';
+			paletteToUpdate = {...paletteToUpdate, color_1};
+	
+			const res = await request(app).put(`/api/v1/palettes/${id}`).send(paletteToUpdate);
+			const palette = await database('palettes').where({id}).first();
 
-			//execution 
-			const res = await request(app).put(`/api/v1/palettes/${id}`).send(paletteToUpdate)
-			console.log(res)
-			const palette = await database('palettes').where({id}).first()
-			//should search in the database for a palette with the matching id of the request and update that palette
-
-			//expected 
-			expect(color_1).toEqual(palette.color_1)
-			expect(res.status).toEqual(200)
-			//a 200 status
+			expect(color_1).toEqual(palette.color_1);
+			expect(res.status).toEqual(200);
 		});
 
 			it('should return a 404 status if request has no matching id', () => {

--- a/server.test.js
+++ b/server.test.js
@@ -75,38 +75,41 @@ describe('Server', () => {
 
 	describe('GET /api/v1/palettes', () => {
 		it('should return all palettes', async () => {
-	// 		//set up 
-	// 		// it should declare expectedPalettes with the palettes database
+			const expectedPalettes = await database('palettes').select();
 
-		const expectedPalettes = await database('palettes').select()
-		expectedPalettes.forEach(palette => {
-				palette.created_at = palette.created_at.toJSON()
-				palette.updated_at = palette.updated_at.toJSON()
-		})
-		// 	//execution
-		// 	//should declare the response with palettes
-	const res = await request(app).get('/api/v1/palettes')
-		// 	//all the palettes with be the response body
- 	const palettes = res.body
+			expectedPalettes.forEach(palette => {
+				palette.created_at = palette.created_at.toJSON();
+				palette.updated_at = palette.updated_at.toJSON();
+			});
+			const res = await request(app).get('/api/v1/palettes');
+	 		const palettes = res.body;
 
-		// 	//expectation
-		// 	//expected palettes to equal expectedPalettes
-
-		expect(palettes).toEqual(expectedPalettes)
-	 });
+			expect(palettes).toEqual(expectedPalettes);
+	 	});
 	});
 
 	describe('GET /api/v1/palettes:id', () => {
-		it('should return a palette with an id that matches the params id', () => {
+		it('should return a palette with an id that matches the params id', async () => {
 			//set up 
+			const expectedPalette = await database('palettes').first()
+			expectedPalette.created_at = expectedPalette.created_at.toJSON();
+			expectedPalette.updated_at = expectedPalette.updated_at.toJSON();
+			const id = expectedPalette.id
+
 			// it should grab the first palette from the database
 			//the id should = the palette id
 
 			//execution
+			const res = await request(app).get(`/api/v1/palettes/${id}`);
+			const palette = res.body[0]
+
+
 			//should declare the palettes 
 			//declare result should take the first palette from the response body
 
 			//expectation
+
+			expect(palette).toEqual(expectedPalette)
 			//expected the result to be the palette with th matching id of the palette 
 		});
 	});

--- a/server.test.js
+++ b/server.test.js
@@ -150,44 +150,31 @@ describe('Server', () => {
 			it('should return a 404 status if request has no matching id', async () => {
 				let paletteToUpdate = await database('palettes').first();
 	
-				const res = await request(app).put('/api/v1/palettes/10').send(paletteToUpdate)
-				const expectedMsg = "{\"error\":\"Couldn't update: Palette does not exist\"}"
+				const res = await request(app).put('/api/v1/palettes/10').send(paletteToUpdate);
+				const expectedMsg = "{\"error\":\"Couldn't update: Palette does not exist\"}";
 
 				expect(res.status).toEqual(404);
-				expect(res.text).toBe(expectedMsg)
-			//setup
-			//it should declare the id of the request
-			//should declare the body of the request as updated palette
-
-			//execution 
-			//should search the database for a matching id
-
-			//expected 
-			//a 404 status will be returned with an error message
+				expect(res.text).toBe(expectedMsg);
 		});
 	});
 
 	describe('DELETE /api/v1/palettes/:id', () => {
-		it('should return a 200 status with a deleted message', () => {
-			//setup
-			//it should declare the id of the request
+		it('should return a 200 status with a deleted message', async () => {
+			const palettes = await database('palettes').select();
+			const expected = await database('palettes').first();
+			await request(app).delete(`/api/v1/palettes/${expected.id}`);
 
-			//execution 
-			//should search the database for a matching id
+			const updatedPalettes = await database('palettes').select();
 
-			//expected 
-			//a 200 status will be returned with a message telling you which palette was deleted
+			expect(updatedPalettes.length).toBe(palettes.length -1);
 		});
 
-			it('should return a 404 status with an error message', () => {
-			//setup
-			//it should declare the id of the request
+			it('should return a 404 status with an error message', async () => {
+			const res = await request(app).delete('/api/v1/palettes/10');
+			const expectedMsg = "{\"error\":\"Could not find palette with id: 10\"}";
 
-			//execution 
-			//should search the database for a matching id
-
-			//expected 
-			//a 404 status will be returned with an error message
+			expect(res.status).toBe(404);
+			expect(res.text).toBe(expectedMsg);
 		});
 	});
 });

--- a/server.test.js
+++ b/server.test.js
@@ -90,42 +90,29 @@ describe('Server', () => {
 
 	describe('GET /api/v1/palettes:id', () => {
 		it('should return a palette with an id that matches the params id', async () => {
-			//set up 
-			const expectedPalette = await database('palettes').first()
+			const expectedPalette = await database('palettes').first();
 			expectedPalette.created_at = expectedPalette.created_at.toJSON();
 			expectedPalette.updated_at = expectedPalette.updated_at.toJSON();
-			const id = expectedPalette.id
 
-			// it should grab the first palette from the database
-			//the id should = the palette id
-
-			//execution
+			const id = expectedPalette.id;
 			const res = await request(app).get(`/api/v1/palettes/${id}`);
-			const palette = res.body[0]
+			const palette = res.body[0];
 
-
-			//should declare the palettes 
-			//declare result should take the first palette from the response body
-
-			//expectation
-
-			expect(palette).toEqual(expectedPalette)
-			//expected the result to be the palette with th matching id of the palette 
+			expect(palette).toEqual(expectedPalette);
 		});
 	});
 
 	describe('POST /api/v1/palettes', () => {
-		it('should post a palette to the palettes database', () => {
+		it('should post a palette to the palettes database', async () => {
 			//setup
-			//it should declare the palette
+			const newPalette = {"color_1": "FFFFFF", "color_2": "FFFFFF", "color_3": "888888", "color_4": "000000", "color_5": "00FFFF"}
 
-			//execution 
-			//result should be declared with the palette posted
-			//palettes should be declared as all the palettes in the database
-
-			//expected 
-			//a 200 reponse
-			//the palette color to be the same as the new palette
+			const response = await request(app).post('/api/v1/palettes').send(newPalette)
+			const id = response.body.id;
+			const palette = await database('palettes').where({ id }).first();
+			
+			expect(palette.color_1).toEqual(newPalette.color_1);
+			expect(response.status).toEqual(201);
 		});
 
 			it('should return an error if a not all required parameters are met', () => {

--- a/server.test.js
+++ b/server.test.js
@@ -152,4 +152,28 @@ describe('PUT /api/v1/palettes/:id', () => {
 		//a 404 status will be returned with an error message
 	});
 });
+
+describe('DELETE /api/v1/palettes/:id', () => {
+	it('should return a 200 status with a deleted message', () {
+		//setup
+		//it should declare the id of the request
+
+		//execution 
+		//should search the database for a matching id
+
+		//expected 
+		//a 200 status will be returned with a message telling you which palette was deleted
+	}
+	
+		it('should return a 404 status with an error message', () {
+		//setup
+		//it should declare the id of the request
+
+		//execution 
+		//should search the database for a matching id
+
+		//expected 
+		//a 404 status will be returned with an error message
+	})
+})
 	

--- a/server.test.js
+++ b/server.test.js
@@ -1,4 +1,4 @@
-const server = require('./server');
+const app = require('./server');
 const request = require('supertest');
 
 const environment = process.env.NODE_ENV || 'test'
@@ -6,10 +6,15 @@ const configuration = require('./knexfile')[environment]
 const database = require('knex')(configuration)
 
 describe('Server', () => {
-	it('should have', () => {
 
+	beforeEach(async () => {
+		await database.seed.run()
 	})
-})
+
+	it('should have', () => {
+		console.log('hello')
+	});
+
 
 //GET /project:
 
@@ -68,112 +73,122 @@ describe('Server', () => {
 	//execution: create var. for response and assign to await request(app).delete(`/project/${id}`), create var for deletedProject and assign to await project DB where({ id: id }).first()
 	//expectation: expect the deletedProject to equal undefined (because it was deleted)
 
-describe('GET /api/v1/palettes', () {
-	it('should return all palettes', () => {
-		//set up 
-		// it should declare expectedPalettes with the palettes database
+	describe('GET /api/v1/palettes', () => {
+		it('should return all palettes', async () => {
+	// 		//set up 
+	// 		// it should declare expectedPalettes with the palettes database
 
-		//execution
-		//should declare the response with palettes
-		//all the palettes with be the response body
+		const expectedPalettes = await database('palettes').select()
+		expectedPalettes.forEach(palette => {
+				palette.created_at = palette.created_at.toJSON()
+				palette.updated_at = palette.updated_at.toJSON()
+		})
+		// 	//execution
+		// 	//should declare the response with palettes
+	const res = await request(app).get('/api/v1/palettes')
+		// 	//all the palettes with be the response body
+ 	const palettes = res.body
 
-		//expectation
-		//expected palettes to equal expectedPalettes
-	})
-})
+		// 	//expectation
+		// 	//expected palettes to equal expectedPalettes
 
-describe('GET /api/v1/palettes:id', () {
-	it('should return a palette with an id that matches the params id', () => {
-		//set up 
-		// it should grab the first palette from the database
-		//the id should = the palette id
+		expect(palettes).toEqual(expectedPalettes)
+	 });
+	});
 
-		//execution
-		//should declare the palettes 
-		//declare result should take the first palette from the response body
+	describe('GET /api/v1/palettes:id', () => {
+		it('should return a palette with an id that matches the params id', () => {
+			//set up 
+			// it should grab the first palette from the database
+			//the id should = the palette id
 
-		//expectation
-		//expected the result to be the palette with th matching id of the palette 
+			//execution
+			//should declare the palettes 
+			//declare result should take the first palette from the response body
+
+			//expectation
+			//expected the result to be the palette with th matching id of the palette 
+		});
+	});
+
+	describe('POST /api/v1/palettes', () => {
+		it('should post a palette to the palettes database', () => {
+			//setup
+			//it should declare the palette
+
+			//execution 
+			//result should be declared with the palette posted
+			//palettes should be declared as all the palettes in the database
+
+			//expected 
+			//a 200 reponse
+			//the palette color to be the same as the new palette
+		});
+
+			it('should return an error if a not all required parameters are met', () => {
+			//setup
+			//it should declare the palette
+
+			//execution 
+			//result should be declared with the palette posted
+			//palettes should be declared as all the palettes in the database
+
+			//expected 
+			//an error status 
+			//a error message
+			//error: 
+	    //      `Expected format: { name: <String> } You're missing "${ requiredParameter }" property.
+		});
+	});
+
+	describe('PUT /api/v1/palettes/:id', () => {
+		it('should return a 200 status if request has a matching id', () => {
+			//setup
+			//it should declare the id of the request
+			//should declare the body of the request as updated palette
+
+			//execution 
+			//should search in the database for a palette with the matching id of the request and update that palette
+
+			//expected 
+			//a 200 status
+		});
+
+			it('should return a 404 status if request has no matching id', () => {
+			//setup
+			//it should declare the id of the request
+			//should declare the body of the request as updated palette
+
+			//execution 
+			//should search the database for a matching id
+
+			//expected 
+			//a 404 status will be returned with an error message
+		});
+	});
+
+	describe('DELETE /api/v1/palettes/:id', () => {
+		it('should return a 200 status with a deleted message', () => {
+			//setup
+			//it should declare the id of the request
+
+			//execution 
+			//should search the database for a matching id
+
+			//expected 
+			//a 200 status will be returned with a message telling you which palette was deleted
+		});
+
+			it('should return a 404 status with an error message', () => {
+			//setup
+			//it should declare the id of the request
+
+			//execution 
+			//should search the database for a matching id
+
+			//expected 
+			//a 404 status will be returned with an error message
+		});
 	});
 });
-
-describe('POST /api/v1/palettes', () {
-	it('should post a palette to the palettes database', () {
-		//setup
-		//it should declare the palette
-
-		//execution 
-		//result should be declared with the palette posted
-		//palettes should be declared as all the palettes in the database
-
-		//expected 
-		//a 200 reponse
-		//the palette color to be the same as the new palette
-	});
-
-		it('should return an error if a not all required parameters are met', () {
-		//setup
-		//it should declare the palette
-
-		//execution 
-		//result should be declared with the palette posted
-		//palettes should be declared as all the palettes in the database
-
-		//expected 
-		//an error status 
-		//a error message
-		//error: 
-    //      `Expected format: { name: <String> } You're missing "${ requiredParameter }" property.
-	});
-});
-
-describe('PUT /api/v1/palettes/:id', () => {
-	it('should return a 200 status if request has a matching id', () {
-		//setup
-		//it should declare the id of the request
-		//should declare the body of the request as updated palette
-
-		//execution 
-		//should search in the database for a palette with the matching id of the request and update that palette
-
-		//expected 
-		//a 200 status
-	});
-
-		it('should return a 404 status if request has no matching id', () {
-		//setup
-		//it should declare the id of the request
-		//should declare the body of the request as updated palette
-
-		//execution 
-		//should search the database for a matching id
-
-		//expected 
-		//a 404 status will be returned with an error message
-	});
-});
-
-describe('DELETE /api/v1/palettes/:id', () => {
-	it('should return a 200 status with a deleted message', () {
-		//setup
-		//it should declare the id of the request
-
-		//execution 
-		//should search the database for a matching id
-
-		//expected 
-		//a 200 status will be returned with a message telling you which palette was deleted
-	}
-	
-		it('should return a 404 status with an error message', () {
-		//setup
-		//it should declare the id of the request
-
-		//execution 
-		//should search the database for a matching id
-
-		//expected 
-		//a 404 status will be returned with an error message
-	})
-})
 	

--- a/server.test.js
+++ b/server.test.js
@@ -68,5 +68,18 @@ describe('Server', () => {
 	//execution: create var. for response and assign to await request(app).delete(`/project/${id}`), create var for deletedProject and assign to await project DB where({ id: id }).first()
 	//expectation: expect the deletedProject to equal undefined (because it was deleted)
 
+describe('GET /api/v1/palettes', () {
+	it('should return all palettes', () => {
+		//set up 
+		// it should declare expectedPalettes with the palettes database
+
+		//execution
+		//should declare the response with palettes
+		//all the palettes with be the response body
+
+		//expectation
+		//expected palettes to equal expectedPalettes
+	})
+})
 
 	


### PR DESCRIPTION
-Added testing for palette
-Get
-Get by id: sad and happy path
-Post: sad and happy path
-Put: sad and happy path
-Delete: sad and happy path

-changed const at top of test file to app instead of server
-updated the palette get, originally the .then was before the querying of the database
-added a before each

*changed port, but we can change back to 3001 if you want
